### PR TITLE
ECS CFS Stack for Prefect 1.0 Server and ECS Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .terraform.*
 .terraform.lock.hcl
 terraform.*
+.venv

--- a/ecs/cloudformation/README.md
+++ b/ecs/cloudformation/README.md
@@ -1,0 +1,31 @@
+# Prefect ECS Deployment Cloudformation Templates
+
+AWS Cloudformation templates to deploy a Prefect 1.0 Server and Agent on Elastic Container Service (ECS)  
+
+
+## Requirements: 
+
+**Prefect Agent:**
+    -- A VPC
+    -- ARN of IAM ecsTaskExecutionRole 
+    -- Prefect API URL IF using Server Backend
+    -- Prefect Cloud API Key IF using Cloud Backend
+    -- **Useful**
+        -- Custom Prefect Task Execution Role
+
+
+**Prefect Server:** 
+    -- A VPC
+    -- ARN of Application Load Balancer
+    -- ARN of TargetGroup on ALB that handles Port 443
+    -- ARN of SSL Certificates
+    -- ARN IAM ecsTaskExecutionRole or Custom Task Execution Role 
+    -- DB Connection String to Existing Postgres DB
+    -- Prefect Domain Name
+    -- **Useful**
+        -- ALB Listener To Redirect Traffic from Port 443 to Internet Accessible Security Group 
+        -- ALB Listeners to Forward Traffic from Port 4200 to Fixed Response 503
+
+
+
+

--- a/ecs/cloudformation/prefect-agent/cfs-ecs-prefect-agent.yaml
+++ b/ecs/cloudformation/prefect-agent/cfs-ecs-prefect-agent.yaml
@@ -1,0 +1,354 @@
+Description: >
+    Stack for ECS Prefect Agent Deployment
+
+Parameters:
+
+  VPC:
+      Description: The VPC that the ECS cluster is deployed to
+      Type: AWS::EC2::VPC::Id
+
+  ECSClusterARN:
+      Description: Please provide the ARN of ECS Cluster ID that this service should run on
+      Type: String
+
+  ExecutionRole:
+      Description: The ARN of the IAM role that should be used to run the ECS task. This Role should already exist as ecsTaskExecutionRole, if not please create it.
+      Type: String
+
+  TaskRole:
+      Description: The ARN of the Prefect IAM Role for ECS Task Execution. If no TaskRole is provided, one will be created that has widely used policies for Prefect.  
+      Type: String
+
+  LaunchType:
+      Description: The launch type for the ECS task, either EC2 or FARGATE
+      Type: String
+      Default: EC2
+
+  PrefectAPIURL: 
+      Description: Prefect API URL
+      Type: String
+
+  PrefectImage: 
+      Description: The ECS image to use for the task
+      Type: String
+      Default: prefecthq/prefect:latest
+
+  PrefectBackend: 
+      Description: Wher to use Prefect Server or Prefect Cloud
+      Type: String
+      Default: server
+
+  PrefectCloudAPIKey:
+      Description: API Key if Prefect Cloud is the Backend
+      Type: String
+
+
+Conditions:
+  UseFargate: !Equals [!Ref LaunchType, Fargate]
+  UseEC2: !Equals [!Ref LaunchType, EC2]
+  CreatePrefectTaskRole: !Equals [!Ref TaskRole, NONE]
+
+
+Resources:
+
+  CloudwatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Join ['-', [ECSLogGroup, 'prefect-agent']]
+            RetentionInDays: 14
+    
+  # This is a role which is used by the ECS tasks themselves.
+  PrefectTaskRole:
+    Condition: CreatePrefectTaskRole
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs-tasks.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+                # Allow the ECS Tasks to download images from ECR
+                - 'ecr:GetAuthorizationToken'
+                - 'ecr:BatchCheckLayerAvailability'
+                - 'ecr:GetDownloadUrlForLayer'
+                - 'ecr:BatchGetImage'
+
+                # Allow the ECS tasks to upload logs to CloudWatch
+                - 'logs:CreateLogStream'
+                - 'logs:PutLogEvents'
+
+              Resource: '*'
+
+
+
+  PrefectTaskGetPassRolePolicy:
+      Condition: CreatePrefectTaskRole
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: "Prefect-GetPassTaskRole" 
+        PolicyDocument: 
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: 
+            - iam:GetRole
+            - iam:PassRole
+            Resource:
+            - !Ref ExecutionRole
+          Roles: 
+            - !Ref PrefectTaskRole
+
+  PrefectTaskLogRolePolicy:
+      Condition: CreatePrefectTaskRole
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: "Prefect-LogRole" 
+        PolicyDocument: 
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            - logs:GetLogEvents
+            Resource: "*"
+          Roles: 
+            - !Ref PrefectTaskRole
+
+    
+  PrefectTaskECSRolePolicy:
+      Condition: CreatePrefectTaskRole
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: "Prefect-ECSRole"
+        PolicyDocument: 
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DescribeVpcs
+              - ec2:DescribeSubnets
+              - ec2:DescribeSecurityGroups
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:CreateSecurityGroup
+              - ec2:CreateTags
+              - ec2:DeleteSecurityGroup
+              - ecs:DeregisterTaskDefinition
+              - ecs:ListAccountSettings
+              - ecs:CreateCluster
+              - ecs:RegisterTaskDefinition
+              - ecs:ListTaskDefinitions
+              - ecs:DescribeTaskDefinition
+              - ecs:ListClusters"
+              - ecs:RunTask
+              - ecs:StopTask
+              - ecs:DeleteCluster
+              - ecs:DescribeTasks
+              - ecs:DescribeCluster
+            Resource: "*"
+          Roles: 
+            - !Ref PrefectTaskRole
+
+  PrefectTaskAgentRolePolicy:
+      Condition: CreatePrefectTaskRole
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: "Prefect-AgentRole"
+        PolicyDocument: 
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:CreateSecurityGroup
+              - ec2:CreateTags
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DescribeSecurityGroups
+              - ec2:DescribeSubnets
+              - ec2:DescribeVpcs
+              - ec2:DeleteSecurityGroup
+              - ecs:CreateCluster
+              - ecs:DeleteCluster
+              - ecs:DeregisterTaskDefinition
+              - ecs:DescribeClusters
+              - ecs:DescribeTaskDefinition
+              - ecs:DescribeTasks
+              - ecs:ListAccountSettings
+              - ecs:ListClusters
+              - ecs:ListTaskDefinitions
+              - ecs:RegisterTaskDefinition
+              - ecs:RunTask
+              - ecs:StopTask
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - logs:DescribeLogGroups
+              - logs:GetLogEvent
+            Resource: "*"
+          Roles: 
+            - !Ref PrefectTaskRole
+
+  PrefectTasS3RolePolicy:
+      Condition: CreatePrefectTaskRole
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: "Prefect-S3SecretsRole"
+        PolicyDocument: 
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - "s3:*"
+              - "secretsmanager:*"
+            Resource: "*"
+        Roles: 
+          - !Ref PrefectTaskRole
+
+
+  PrefectEC2AgentTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Condition: UseEC2
+    Properties:
+      Family: prefect-agent-ecs
+      Memory: 1gb
+      ExecutionRoleArn: !Ref ExecutionRole 
+      TaskRoleArn: !If [CreatePrefectTaskRole, !Ref PrefectTaskRole, !Ref TaskRole]
+      Volumes:
+      - Name: docker_sock
+        Host:
+          SourcePath: "/var/run/docker.sock"
+      - Name: docker_bin
+        Host:
+          SourcePath: "/usr/bin/docker"
+      ContainerDefinitions:
+        - Name: prefect-ecs-agent
+          Image: !Ref PrefectImage
+          Privileged: true
+          Essential: true
+          Command:
+          - prefect 
+          - agent 
+          - ecs 
+          - start 
+          - -a 
+          - !Ref PrefectAPIURL 
+          - --launch-type
+          - !Ref LaunchType 
+          - --execution-role-arn 
+          - !Ref ExecutionRole 
+          - --task-role-arn
+          - !If [CreatePrefectTaskRole, !Ref PrefectTaskRole, !Ref TaskRole]
+          - --log-level
+          - DEBUG
+          MountPoints:
+          - SourceVolume: docker_sock
+            ContainerPath: "/var/run/docker.sock"
+          - SourceVolume: docker_bin
+            ContainerPath: "/usr/bin/docker"
+          Environment:
+          - Name: PREFECT__CLOUD__AGENT__LABELS
+            Value: "['ecs']"
+          - Name: PREFECT__CLOUD__AGENT__LEVEL
+            Value: DEBUG
+          - Name: AWS_DEFAULT_REGION
+            Value: !Ref "AWS::Region"
+          - Name: PREFECT__CLOUD__API_KEY
+            Value: !Ref PrefectCloudAPIKey
+          - Name: PREFECT__SERVER__API
+            Value: !Ref PrefectAPIURL
+          - Name: PREFECT__BACKEND
+            Value: !Ref PrefectBackend
+          - Name: AWS_RETRY_MODE
+            Value: adaptive
+          - Name: AWS_MAX_ATTEMPTS
+            Value: '10'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: ecs
+              awslogs-create-group: 'true'
+
+  PrefectFargateAgentTaskDefinition:
+    Condition: UseFargate
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: prefect-agent-ecs
+      Memory: 1gb
+      ExecutionRoleArn: !Ref ExecutionRole 
+      TaskRoleArn: !If [CreatePrefectTaskRole, !Ref PrefectTaskRole,  !Ref TaskRole]
+      ContainerDefinitions:
+        - Name: prefect-ecs-agent
+          Image: !Ref PrefectImage
+          Essential: true
+          Command:
+          - prefect 
+          - agent 
+          - ecs 
+          - start 
+          - -a 
+          - !Ref PrefectAPIURL 
+          - --launch-type
+          - !Ref LaunchType 
+          - --execution-role-arn 
+          - !Ref ExecutionRole 
+          - --task-role-arn
+          - !If [CreatePrefectTaskRole, !Ref PrefectTaskRole, !Ref TaskRole]
+          - --log-level
+          - DEBUG
+          Environment:
+          - Name: PREFECT__CLOUD__AGENT__LABELS
+            Value: "['ecs']"
+          - Name: PREFECT__CLOUD__AGENT__LEVEL
+            Value: DEBUG
+          - Name: AWS_DEFAULT_REGION
+            Value: !Ref "AWS::Region"
+          - Name: PREFECT__CLOUD__API_KEY
+            Value: !Ref PrefectCloudAPIKey
+          - Name: PREFECT__SERVER__API
+            Value: !Ref PrefectAPIURL
+          - Name: PREFECT__BACKEND
+            Value: !Ref PrefectBackend
+          - Name: AWS_RETRY_MODE
+            Value: adaptive
+          - Name: AWS_MAX_ATTEMPTS
+            Value: '10'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: ecs
+              awslogs-create-group: 'true'
+
+  PrefectService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSClusterARN
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      PlacementStrategies:
+          - Type: spread
+            Field: attribute:ecs.availability-zone
+          - Type: spread
+            Field: instanceId
+      Tags:
+      - Key: Prefect
+        Value: prefect-server
+      TaskDefinition: 
+        !If [UseFargate, !Ref PrefectFargateAgentTaskDefinition, !Ref PrefectEC2AgentTaskDefinition]
+
+
+      

--- a/ecs/cloudformation/prefect-server/cfs-ecs-prefect-server.yaml
+++ b/ecs/cloudformation/prefect-server/cfs-ecs-prefect-server.yaml
@@ -1,0 +1,373 @@
+# Prefect ECS Deployment Cloudformation Templates
+
+
+Description: >
+    Stack for ECS Prefect Server Deployment
+  
+Parameters:
+
+  EnvironmentName:
+      Description: An environment name that will be prefixed to resource names
+      Type: String
+      Default: prefect-dev
+
+  VPC:
+      Description: The VPC that the ECS cluster is deployed to
+      Type: AWS::EC2::VPC::Id
+
+  ECSClusterARN:
+      Description: Please provide the ARN of ECS Cluster ID that this service should run on
+      Type: String
+
+  TaskRole: 
+      Description: The ARN of the Prefect IAM Role to create and assign to ECS Task
+      Type: String
+  
+  CustomTaskRole:
+      Description: The ARN of the Prefect IAM Role to create and assign to ECS Task
+      Type: String
+
+  ALBArn:
+      Description: ARN of ALB
+      Type: String
+
+  443TargetGroup:
+      Description: Target Group for ALB 443
+      Type: String
+
+  ALB443Listener:
+      Description: ARN of ALB Listener for 443 to attach this container to, if left blank a new one will be created for you
+      Type: String
+
+  ALB4200Listener:
+      Description: ARN of ALB Listener for 4200 to attach this container to, if left blank a new one will be created for you
+      Type: String
+
+  Certificate: 
+      Description: ARN of the certificate to attach to the ALB Listener
+      Type: String
+
+  PostgresDB:
+      Description: Postgres DB to connect to
+      Type: String
+
+  PrefectDomainName:
+      Description: Prefect Domain Name
+      Type: String
+
+Conditions: 
+  Create443Listener: !Equals [!Ref ALB443Listener, NONE]
+  Create4200Listener: !Equals [!Ref ALB4200Listener, NONE]
+  UseCustomTaskRole: !Not [!Equals [!Ref CustomTaskRole, NONE]]
+
+Resources:
+
+  NewALB443Listener:
+      Type: "AWS::ElasticLoadBalancingV2::Listener"
+      Condition: Create443Listener
+      Properties:
+        DefaultActions:
+          - Type: "forward"
+            ForwardConfig:
+              TargetGroups: 
+                - TargetGroupArn: !Ref 443TargetGroup
+                  Weight: "1" 
+        LoadBalancerArn: !Ref ALBArn
+        Port: 443
+        Protocol: "HTTPS"
+        Certificates:
+          - CertificateArn: !Ref Certificate
+
+  NewALB4200Listener:
+      Type: "AWS::ElasticLoadBalancingV2::Listener"
+      Condition: Create4200Listener
+      Properties:
+        DefaultActions:
+          - Type: "fixed-response"
+            FixedResponseConfig:
+              StatusCode: "503"
+        LoadBalancerArn: !Ref ALBArn
+        Port: 4200
+        Protocol: "HTTPS"
+        Certificates:
+          - CertificateArn: !Ref Certificate
+
+  CloudwatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Join ['-', [ECSLogGroup, 'prefect-server']]
+            RetentionInDays: 14
+
+  PrefectTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      TaskRoleArn: 
+        !If [UseCustomTaskRole, !Ref CustomTaskRole, !Ref TaskRole]
+      Family: prefect-server
+      Memory: "512"
+      ContainerDefinitions:
+        - Name: apollo
+          Essential: true
+          DependsOn: 
+            - Condition: HEALTHY
+              ContainerName: graphql
+            - Condition: HEALTHY
+              ContainerName: hasura
+          Image: docker.io/prefecthq/apollo:latest
+          Command:
+          - bash
+          - -c
+          - /apollo/post-start.sh && npm run serve
+          Environment:
+          - Name: GRAPHQL_SERVICE_HOST
+            Value: http://graphql
+          - Name: GRAPHQL_SERVICE_PORT
+            Value: 4201
+          - Name: HASURA_API_URL
+            Value: http://hasura:3000/v1alpha1/graphql
+          - Name: PREFECT_API_HEALTH_URL
+            Value: http://graphql:4201/health
+          - Name: PREFECT_API_URL
+            Value: http://graphql:4201/graphql/
+          - Name: PREFECT_SERVER__TELEMETRY__ENABLED
+            Value: "false"
+          HealthCheck:
+            Command:
+            - CMD-SHELL
+            - curl --fail --silent "http://localhost:4200/.well-known/apollo/server-health" &> /dev/null || exit 1
+            Interval: 60
+          PortMappings:
+          - ContainerPort: 4200
+            HostPort: 4200
+            Protocol: HTTP
+          Links:
+            - graphql
+            - hasura
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: !Ref EnvironmentName
+
+
+        - Name: graphql
+          Essential: true
+          Image: docker.io/prefecthq/server:latest
+          Command:
+            - bash
+            - -c
+            - prefect-server database upgrade -y && python src/prefect_server/services/graphql/server.py
+          Environment:
+          - Name: PREFECT_CORE_VERSION
+            Value: 1.2.0
+          - Name: PREFECT_SERVER_DB_CMD
+            Value: prefect-server database upgrade -y
+          - Name: PREFECT_SERVER__DATABASE__CONNECTION_URL
+            Value: !Ref PostgresDB
+          - Name: PREFECT_SERVER__HASURA__ADMIN_SECRET
+            Value: hasura-secret-admin-secret
+          - Name: PREFECT_SERVER__HASURA__HOST
+            Value: hasura
+          HealthCheck:
+            Command:
+            - CMD-SHELL
+            - curl --fail --silent "http://localhost:4201/health" &> /dev/null || exit 1
+            Interval: 60
+          PortMappings:
+          - ContainerPort: 4201
+            HostPort: 4201
+            Protocol: HTTP
+          Links: 
+            - hasura
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: !Ref EnvironmentName
+
+
+        - Name: hasura
+          Essential: true
+          Image: docker.io/hasura/graphql-engine:v2.0.9
+          Command:
+          - graphql-engine
+          - serve
+          Environment:
+          - Name: HASURA_GRAPHQL_DATABASE_URL
+            Value: !Ref PostgresDB
+          - Name: HASURA_GRAPHQL_ENABLE_CONSOLE
+            Value: "true"
+          - Name: HASURA_GRAPHQL_LOG_LEVEL
+            Value: warn
+          - Name: HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE
+            Value: "100"
+          - Name: HASURA_GRAPHQL_SERVER_PORT
+            Value: "3000"
+          HealthCheck:
+            Command: 
+              - CMD-SHELL
+              - wget -O - http://localhost:3000/healthz &>/dev/null || exit 1
+            Interval: 60
+          PortMappings:
+          - ContainerPort: 3000
+            HostPort: 3000
+            Protocol: HTTP
+          
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: !Ref EnvironmentName
+
+        - Name: towel
+          Essential: true
+          Image: docker.io/prefecthq/server:latest
+          DependsOn: 
+            - Condition: HEALTHY
+              ContainerName: graphql
+          Command:
+          - python
+          - src/prefect_server/services/towel/__main__.py
+          Environment:
+          - Name: PREFECT_SERVER__HASURA__ADMIN_SECRET
+            Value: hasura-secret-admin-secret
+          - Name: PREFECT_SERVER__HASURA__HOST
+            Value: hasura
+          Links:
+            - hasura
+
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: !Ref EnvironmentName
+
+
+        - Name: prefect-ui
+          Image: docker.io/prefecthq/ui:latest
+          Essential: true
+          Command:
+          - /intercept.sh
+          Environment:
+          - Name: PREFECT_SERVER__APOLLO_URL
+            Value:  
+              !Sub
+                - 'http://${Domain}:4200/graphql'
+                - { Domain: !Ref PrefectDomainName }
+          HealthCheck:
+            Command:
+            - CMD-SHELL
+            - curl --fail --silent --head "http://localhost:8080" &> /dev/null || exit 1
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+          PortMappings:
+          - ContainerPort: 8080
+            HostPort: 0
+            Protocol: HTTP
+          Links:
+          - apollo
+        
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudwatchLogsGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: !Ref EnvironmentName
+
+  
+  PrefectTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: 8080
+      Protocol: HTTP
+      Name: prefect-ui
+      Tags:
+      - Key: Prefect
+        Value: ui
+      VpcId:
+        Ref: VPC 
+
+  
+  ApolloTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: /.well-known/apollo/server-health
+      Port: 4200
+      Protocol: HTTP
+      Name: prefect-apollo
+      Tags:
+      - Key: Prefect
+        Value: apollo
+      VpcId:
+        Ref: VPC 
+
+  ApolloListener:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn:
+        - PrefectTargetGroup
+    Properties:
+      ListenerArn:
+        !If [Create4200Listener, !Ref  NewALB4200Listener, !Ref ALB4200Listener]
+      Priority: 101
+      Conditions:
+        - Field: host-header
+          Values:
+              - !Ref PrefectDomainName
+      Actions:
+        - TargetGroupArn: 
+            Ref: ApolloTargetGroup
+          Type: forward
+  
+  PrefectListener:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn:
+        - PrefectTargetGroup
+    Properties:
+      ListenerArn:
+        !If [Create443Listener, !Ref NewALB443Listener, !Ref ALB443Listener]
+      Priority: 408
+      Conditions:
+        - Field: host-header
+          Values:
+              - !Ref PrefectDomainName
+      Actions:
+        - TargetGroupArn: 
+            Ref: PrefectTargetGroup
+          Type: forward
+
+  
+  PrefectService:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - PrefectListener
+    Properties:
+      Cluster: !Ref ECSClusterARN
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      LoadBalancers:
+      - ContainerName: prefect-ui
+        ContainerPort: 8080
+        TargetGroupArn:
+          Ref: PrefectTargetGroup
+      - ContainerName: apollo
+        ContainerPort: 4200
+        TargetGroupArn:
+          Ref: ApolloTargetGroup
+      PlacementStrategies:
+          - Type: spread
+            Field: attribute:ecs.availability-zone
+          - Type: spread
+            Field: instanceId
+      Tags:
+      - Key: Prefect
+        Value: prefect-server
+      TaskDefinition:
+        Ref: PrefectTaskDefinition
+


### PR DESCRIPTION
# Summary 
I noticed there are not many ECS related issues, so I figured I would add what I have.  This PR includes a CFS Template for deploying an ECS Agent, as well as a CFS Template for deploying Prefect Server 1.0 into ECS. 


# Feedback Requested

The CFS Template for Prefect Server was not built for general usability. I have started to refactor the template for general use but before I went too far I thought it would be best to get some feedback. 

# Weirdness 

The one thing that may look weird in the ECSAgent is the Docker sock and bin mounts in the "Use EC2 LauchType" Task definition. The reason why we do this is so we can utilize Docker in Docker (DnD). We use DnD, to build images dynamically from GitHub with an initial Parent Flow and then utilize that image downstream in subflows.  
