### PR TITLE
Account for new categories under devops/ folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Prefect 2.0
 flows-advanced/ @gabcoyne @robfreedy @serinamarie @zzstoatzz
 flows-starter/ @gabcoyne @robfreedy @serinamarie  @zzstoatzz
+devops/ @gabcoyne @jamiedick @prefectcboyd # default
 devops/github-actions/ @prefectcboyd @robfreedy @serinamarie @zzstoatzz
 devops/infrastructure-as-code/ @gabcoyne @jamiedick @prefectcboyd
 
@@ -18,6 +19,7 @@ video-demos/ @gabcoyne @prefectcboyd @robfreedy @serinamarie
 # .github/CODEOWNERS change will still alert all
 
 # Legacy: Prefect < 2.0 folders are unlikely to see additions/mods
+prefect-v1-legacy/devops/ @gabcoyne @jamiedick @prefectcboyd # default 
 prefect-v1-legacy/devops/github-actions/ @prefectcboyd @robfreedy @serinamarie @zzstoatzz
 prefect-v1-legacy/devops/infrastructure-as-code/ @gabcoyne @jamiedick @prefectcboyd @robfreedy
 prefect-v1-legacy/graphql-queries/ @prefectcboyd @robfreedy


### PR DESCRIPTION
`CODEOWNERS` will now account for any new subfolders created under `devops/`, pinging only the default `devops/` owners instead of all codeowners.