### PR TITLE
Add issues templates for bugs and feature requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,12 @@
 # Prefect 2.0
 flows-advanced/ @gabcoyne @robfreedy @serinamarie @zzstoatzz
 flows-starter/ @gabcoyne @robfreedy @serinamarie  @zzstoatzz
-devops/ @gabcoyne @jamiedick @prefectcboyd # default
+devops/ @gabcoyne @jamiedick @prefectcboyd  # default
 devops/github-actions/ @prefectcboyd @robfreedy @serinamarie @zzstoatzz
 devops/infrastructure-as-code/ @gabcoyne @jamiedick @prefectcboyd
 
 # General
+.github/ @gabcoyne @robfreedy @zzstoatzz  # default
 .github/workflows/codeql.yml @robfreedy @zzstoatzz
 .github/workflows/python.yml @gabcoyne @serinamarie @zzstoatzz
 .github/workflows/terraform-action.yml @gabcoyne @jamiedick @prefectcboyd
@@ -19,7 +20,7 @@ video-demos/ @gabcoyne @prefectcboyd @robfreedy @serinamarie
 # .github/CODEOWNERS change will still alert all
 
 # Legacy: Prefect < 2.0 folders are unlikely to see additions/mods
-prefect-v1-legacy/devops/ @gabcoyne @jamiedick @prefectcboyd # default 
+prefect-v1-legacy/devops/ @gabcoyne @jamiedick @prefectcboyd  # default 
 prefect-v1-legacy/devops/github-actions/ @prefectcboyd @robfreedy @serinamarie @zzstoatzz
 prefect-v1-legacy/devops/infrastructure-as-code/ @gabcoyne @jamiedick @prefectcboyd @robfreedy
 prefect-v1-legacy/graphql-queries/ @prefectcboyd @robfreedy

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,39 @@
+name: "🐛 Bug Report"
+description: "If something isn't working as expected 🤔."
+title: "[Bug]: "
+labels: ["i: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+
+  - type: checkboxes
+    id: input1
+    attributes:
+      label: "💻"
+      options:
+        - label: Would you like to work on a fix?
+      
+  - type: textarea
+    attributes:
+      label: Current behavior
+      description: A clear and concise description of the current behavior.
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of you would expect.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Possible solution
+      description: "If you have suggestions on a fix for the bug."
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: "Add any other context about the problem here. Or a screenshot if applicable."

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: "🐛 Bug Report"
-description: "If something isn't working as expected 🤔."
+description: "If something in this repo isn't working as expected 🤔."
 title: "[Bug]: "
 labels: ["i: bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🗣 Ask a Question, Discuss
+    url: https://github.com/PrefectHQ/prefect-recipes/discussions
+    about: How does X work 🤔? I made this! I have an idea...

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,13 @@
-blank_issues_enabled: false
 contact_links:
-  - name: 🗣 Ask a Question, Discuss
-    url: https://github.com/PrefectHQ/prefect-recipes/discussions
-    about: How does X work 🤔? I made this! I have an idea...
+  - name: 📖 Read the documentation
+    url: https://docs.prefect.io/
+    about: Please consult the documentation before opening any issues!
+  - name: 🙋 Ask a question
+    url: https://discourse.prefect.io/c/21
+    about: Ask questions about how to use Prefect on our Discourse forum.
+  - name: 💬 Chat with an expert
+    url: https://www.prefect.io/slack
+    about: Live chat with Prefect experts, engineers, and users on our Slack community.
+  - name: 🏗️ Contact us about professional services
+    url: https://www.prefect.io/#contact
+    about: Contact the Prefect sales team for paid support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,44 @@
+name: "🚀 Recipe Request"
+description: "I have a specific suggestion for prefect-recipes!"
+labels: ["i: enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to suggest a new feature! Please fill out this form as completely as possible.
+
+  - type: checkboxes
+    id: input1
+    attributes:
+      label: "💻"
+      description: |
+        Check this if you would like to implement a PR, we are more than happy to help you go through the process
+      options:
+        - label: Would you like to work on this feature?
+
+  - type: textarea
+    attributes:
+      label: What problem are you trying to solve?
+      description: |
+        A concise description of what the problem is.
+      placeholder: |
+        I have an issue when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Documentation, Adoption, Migration Strategy
+      description: |
+        If you can, explain how users will be able to use this and how it might be documented. Maybe a mock-up?


### PR DESCRIPTION
## Description

Make it easy for repo users to

1. point out any bugs in the recipes
2. allow for requests/opportunity for community members to implement those requests. For instance, I heard that when a community member implements a feature request they get some amazing swag! ;) Otherwise maybe someone from CS takes it up.
3. Updates `CODEOWNERS` to account for new folders in `.github/`

## Type of change
- [X] New feature (non-breaking change which adds functionality)