### PR TITLE
add github action recipe for creating deployment referencing storage and infra blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here you'll find starter code and more advanced example use cases.
 - [Setup an Azure VM and Run the Prefect Agent](./devops/infrastructure-as-code/azure/prefect-agent-on-avm/)
 
 #### Github Actions
-- [Create Deployment with storage and infra Blocks on push to main](./devops/github-actions/general-docker-deploy.yaml)
+- [Create Deployment with storage and infra Blocks on push to branch](./devops/github-actions/general-docker-deploy.yaml)
 
 #### Prefect 1.0 Legacy
 - [Register a Prefect Flow](./prefect-v1-legacy/devops/github-actions/)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Here you'll find starter code and more advanced example use cases.
 - [Deploy Prefect Orion to an AKS Cluster with Azure Blob Storage](./devops/infrastructure-as-code/azure/prefect-agent-on-aks/)
 - [Setup an Azure VM and Run the Prefect Agent](./devops/infrastructure-as-code/azure/prefect-agent-on-avm/)
 
+#### Github Actions
+- [Create Deployment with storage and infra Blocks on push to main](./devops/github-actions/general-docker-deploy.yaml)
+
 #### Prefect 1.0 Legacy
 - [Register a Prefect Flow](./prefect-v1-legacy/devops/github-actions/)
 - [Run GraphQL Queries](./prefect-v1-legacy/graphql-queries/)

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -1,0 +1,61 @@
+on:
+  push:
+    branches:
+      - "main"
+      - "dev"
+
+env:
+  FLOWNAME: marvin
+  IMAGE: ${{secrets.IMAGE_REGISTRY_SLASH_IMAGE_REPO}}:latest
+  DEPLOYMENTYAML: ./marvin.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Extract the current branch name to reference Blocks corresponding to this environment
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Build the image
+        run: |
+          docker build . --tag ${{ env.IMAGE }} -f ./Dockerfile
+
+      # Replace if needed with plugin in ECR, GCR, GHCR, etc 
+      - name: Login to registry
+        env:
+          CONTAINER_REGISTRY_USER: ${{secrets.CONTAINER_REGISTRY_USER}}
+          CONTAINER_REGISTRY_PASSWORD: ${{secrets.CONTAINER_REGISTRY_PASSWORD}}
+        run: |
+          docker login -u $CONTAINER_REGISTRY_USER -p $CONTAINER_REGISTRY_PASSWORD 
+
+      - name: Push to container registry
+        run: docker push ${{ env.IMAGE }}
+
+      - name: Pip update and install prefect
+        run: pip install -U wheel pip prefect s3fs
+
+      - name: Prefect Cloud login
+        run: |
+          prefect config set PREFECT_API_KEY=$API_KEY
+          prefect config set PREFECT_API_URL=$API_URL
+
+        env:
+          API_KEY: ${{ secrets.PREFECT_API_KEY }}
+          API_URL: ${{ secrets.PREFECT_API_URL }}
+
+      # switch out your Block types and names as needed
+      - name: Build Prefect deployment
+        run: prefect deployment build ./marvin.py:$FLOWNAME -n $DEPLOYMENT_NAME -t $TAG -sb $STORAGE -o $DEPLOYMENTYAML -q $WORK_QUEUE
+        env:
+          DEPLOYMENT_NAME: hello-marvin
+          TAG: ${{ steps.extract_branch.outputs.branch }}
+          INFRA: kubernetes-job/default-k8s-job
+          STORAGE: s3/flow-script-storage-${{ steps.extract_branch.outputs.branch }}
+          WORK_QUEUE: ${{ steps.extract_branch.outputs.branch }}-queue
+        
+      - name: Apply Prefect deployment
+        run: prefect deployment apply $DEPLOYMENTYAML

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -8,7 +8,9 @@ env:
   FLOWNAME: marvin
   IMAGE: ${{secrets.IMAGE_REGISTRY_SLASH_IMAGE_REPO}}:latest
   DEPLOYMENTYAML: ./marvin.yaml
-
+  PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
+  PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
+  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,11 +39,6 @@ jobs:
 
       - name: Update Pip, install prefect and required filesystem extras
         run: pip install -U wheel pip prefect s3fs
-
-      - name: Prefect Cloud login
-        run: |
-          prefect config set PREFECT_API_KEY=${{ secrets.PREFECT_API_KEY }}
-          prefect config set PREFECT_API_URL=${{ secrets.PREFECT_API_URL }}
 
       # switch out your Block types and names as needed
       - name: Build Prefect deployment

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Push to container registry
         run: docker push ${{ env.IMAGE }}
 
-      - name: Pip update and install prefect
+      - name: Update Pip, install prefect and required filesystem extras
         run: pip install -U wheel pip prefect s3fs
 
       - name: Prefect Cloud login

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -40,12 +40,8 @@ jobs:
 
       - name: Prefect Cloud login
         run: |
-          prefect config set PREFECT_API_KEY=$API_KEY
-          prefect config set PREFECT_API_URL=$API_URL
-
-        env:
-          API_KEY: ${{ secrets.PREFECT_API_KEY }}
-          API_URL: ${{ secrets.PREFECT_API_URL }}
+          prefect config set PREFECT_API_KEY=${{ secrets.PREFECT_API_KEY }}
+          prefect config set PREFECT_API_URL=${{ secrets.PREFECT_API_URL }}
 
       # switch out your Block types and names as needed
       - name: Build Prefect deployment

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -10,7 +10,8 @@ env:
   DEPLOYMENTYAML: ./marvin.yaml
   PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
   PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
-  
+  FILESYSTEM_EXTRAS: s3fs
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +39,7 @@ jobs:
         run: docker push ${{ env.IMAGE }}
 
       - name: Update Pip, install prefect and required filesystem extras
-        run: pip install -U wheel pip prefect s3fs
+        run: pip install -U wheel pip prefect $FILESYSTEM_EXTRAS
 
       # switch out your Block types and names as needed
       - name: Build Prefect deployment

--- a/devops/github-actions/general-docker-deploy.yaml
+++ b/devops/github-actions/general-docker-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
 
       # switch out your Block types and names as needed
       - name: Build Prefect deployment
-        run: prefect deployment build ./marvin.py:$FLOWNAME -n $DEPLOYMENT_NAME -t $TAG -sb $STORAGE -o $DEPLOYMENTYAML -q $WORK_QUEUE
+        run: prefect deployment build ./marvin.py:$FLOWNAME -n $DEPLOYMENT_NAME -t $TAG -ib $INFRA -sb $STORAGE -o $DEPLOYMENTYAML -q $WORK_QUEUE
         env:
           DEPLOYMENT_NAME: hello-marvin
           TAG: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
## Description
Meant to leverage the separation of environment already provided by github repos, this workflow could be used by any prefect user that needs to create dockerized deployments - can work with any container registry and on any repo branch as long as GitHub secrets and corresponding prefect blocks/work-queues exist.

Defining the `{my}-deployment.yaml` and `Dockerfile` explicitly as "inputs" show that we can use this for any chosen repo structure (monorepos, depoyment 1-to-1 with repo, etc)

## New Recipe Checklist
<!-- If adding a new recipe, please ensure this list is completed. -->
- [x] My PR is in the format of `Add <project-name> recipe`
- [x] My recipe is reproducible and explains everything needed to run successfully. If my code has external dependencies, I make mention of them.
- [x] My code is easily understandable and/or well-commented.
