### PR TITLE
Set PR reminder to Fridays only

### DIFF
--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -2,7 +2,7 @@ name: PR Review Reminder
 
 on:
   schedule:
-    - cron: "0 16 * * 1-5" # M-F @ 11am CST
+    - cron: "0 16 * * 5" # F @ 11am CST
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Problem: PR reminder every day becomes noise.
Proposed solution: Set PR reminder to run only on Fridays. Any other ideas?

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)