### PR TITLE
chore: replaced MARVIN_TOKEN with autogenerated

### DIFF
--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 16 * * 5" # F @ 11am CST
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+
 jobs:
   remind-reviewer:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       - run: echo Sending reminder to requested reviewers.
       - uses: davideviolante/pr-reviews-reminder-action@v1.5.1
         env:
-            GITHUB_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+            GITHUB_TOKEN: ${{ github.token }}
         with:
             webhook-url: ${{ secrets.SLACK_WEBHOOK_RECIPES_CHANNEL }}
             provider: 'slack'


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

^ since this workflow isn't doing anything fancy like cross-repo writes, we can remove the marvin github PAT (which is overly permissive) + use the autogenerated github PAT with the `permissions` config scoped to what this workflow needs to do