### PR TITLE
Remove isort from pre-commit because it conflicts with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ repos:
         exclude: ^helm
       - id: detect-aws-credentials
       - id: detect-private-key
-      
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
         
   - repo: https://github.com/ambv/black
     rev: 22.3.0


### PR DESCRIPTION
## Description

remove isort from pre-commits because it is at odds with black and will cause an infinite loop of failing, then black changing it back, and so on

also I don't think it provides a lot of value here