### PR TITLE
Adds permissions for ECS agent to run ECSTasks

### DIFF
--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
@@ -47,6 +47,7 @@ module "prefect_ecs_agent" {
   prefect_account_id   = "6e02a1db-07de-4760-a15d-60d8fe0b04e1"
   prefect_api_key      = var.prefect_api_key
   prefect_workspace_id = "54cdfc71-9f13-41ba-9492-e1cf24eed185"
+  vpc_id               = "vpc-acfc2092275244ca8"
 }
 ```
 
@@ -63,7 +64,7 @@ Assuming the file structure above, you can run `terraform init` followed by `ter
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
 
 ## Modules
 
@@ -79,6 +80,7 @@ No modules.
 | [aws_ecs_service.prefect_agent_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.prefect_agent_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.prefect_agent_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.prefect_agent_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.prefect_api_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.prefect_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -89,12 +91,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_subnets"></a> [agent\_subnets](#input\_agent\_subnets) | Subnets to place the agent in | `list(string)` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Unique name for this agent deployment | `string` | n/a | yes |
-| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect cloud account ID | `string` | n/a | yes |
-| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect cloud API key | `string` | n/a | yes |
-| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect cloud workspace ID | `string` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
 | <a name="input_agent_cpu"></a> [agent\_cpu](#input\_agent\_cpu) | CPU units to allocate to the agent | `number` | `1024` | no |
 | <a name="input_agent_desired_count"></a> [agent\_desired\_count](#input\_agent\_desired\_count) | Number of agents to run | `number` | `1` | no |
 | <a name="input_agent_extra_pip_packages"></a> [agent\_extra\_pip\_packages](#input\_agent\_extra\_pip\_packages) | Packages to install on the agent assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
@@ -102,7 +98,12 @@ No modules.
 | <a name="input_agent_log_retention_in_days"></a> [agent\_log\_retention\_in\_days](#input\_agent\_log\_retention\_in\_days) | Number of days to retain agent logs for | `number` | `30` | no |
 | <a name="input_agent_memory"></a> [agent\_memory](#input\_agent\_memory) | Memory units to allocate to the agent | `number` | `2048` | no |
 | <a name="input_agent_queue_name"></a> [agent\_queue\_name](#input\_agent\_queue\_name) | Prefect queue that the agent should listen to | `string` | `"default"` | no |
-| <a name="input_agent_task_role_arn"></a> [agent\_task\_role\_arn](#input\_agent\_task\_role\_arn) | Optional task role ARN to pass to the agent | `string` | `""` | no |
+| <a name="input_agent_subnets"></a> [agent\_subnets](#input\_agent\_subnets) | Subnets to place the agent in | `list(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Unique name for this agent deployment | `string` | n/a | yes |
+| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect cloud account ID | `string` | n/a | yes |
+| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect cloud API key | `string` | n/a | yes |
+| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect cloud workspace ID | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
 
 ## Outputs
 

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
@@ -53,6 +53,14 @@ module "prefect_ecs_agent" {
 
 Assuming the file structure above, you can run `terraform init` followed by `terraform apply` to create the resources. Check out the [Inputs](#inputs) section below for more options.
 
+## Reference
+
+The [terraform docs](https://terraform-docs.io/) below can be generated with the following command:
+
+```sh
+terraform-docs markdown table . --output-file README.md
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -99,6 +107,7 @@ No modules.
 | <a name="input_agent_memory"></a> [agent\_memory](#input\_agent\_memory) | Memory units to allocate to the agent | `number` | `2048` | no |
 | <a name="input_agent_queue_name"></a> [agent\_queue\_name](#input\_agent\_queue\_name) | Prefect queue that the agent should listen to | `string` | `"default"` | no |
 | <a name="input_agent_subnets"></a> [agent\_subnets](#input\_agent\_subnets) | Subnets to place the agent in | `list(string)` | n/a | yes |
+| <a name="input_agent_task_role_arn"></a> [agent\_task\_role\_arn](#input\_agent\_task\_role\_arn) | Optional task role ARN to pass to the agent. If not defined, a task role will be created | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Unique name for this agent deployment | `string` | n/a | yes |
 | <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect cloud account ID | `string` | n/a | yes |
 | <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect cloud API key | `string` | n/a | yes |
@@ -109,7 +118,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_prefect_agent_cluster"></a> [prefect\_agent\_cluster](#output\_prefect\_agent\_cluster) | n/a |
+| <a name="output_prefect_agent_cluster_name"></a> [prefect\_agent\_cluster\_name](#output\_prefect\_agent\_cluster\_name) | n/a |
 | <a name="output_prefect_agent_execution_role_arn"></a> [prefect\_agent\_execution\_role\_arn](#output\_prefect\_agent\_execution\_role\_arn) | n/a |
 | <a name="output_prefect_agent_security_group"></a> [prefect\_agent\_security\_group](#output\_prefect\_agent\_security\_group) | n/a |
 | <a name="output_prefect_agent_service_id"></a> [prefect\_agent\_service\_id](#output\_prefect\_agent\_service\_id) | n/a |

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/README.md
@@ -109,5 +109,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_prefect_agent_cluster"></a> [prefect\_agent\_cluster](#output\_prefect\_agent\_cluster) | n/a |
+| <a name="output_prefect_agent_execution_role_arn"></a> [prefect\_agent\_execution\_role\_arn](#output\_prefect\_agent\_execution\_role\_arn) | n/a |
+| <a name="output_prefect_agent_security_group"></a> [prefect\_agent\_security\_group](#output\_prefect\_agent\_security\_group) | n/a |
 | <a name="output_prefect_agent_service_id"></a> [prefect\_agent\_service\_id](#output\_prefect\_agent\_service\_id) | n/a |
+| <a name="output_prefect_agent_task_role_arn"></a> [prefect\_agent\_task\_role\_arn](#output\_prefect\_agent\_task\_role\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
@@ -52,7 +52,7 @@ resource "aws_ecs_task_definition" "prefect_agent_task_definition" {
   // Execution role allows ECS to create tasks and services
   execution_role_arn = aws_iam_role.prefect_agent_execution_role.arn
   // Task role allows tasks and services to access other AWS resources
-  task_role_arn = var.agent_task_role_arn
+  task_role_arn = aws_iam_role.prefect_agent_task_role.arn
 }
 
 resource "aws_ecs_service" "prefect_agent_service" {

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
@@ -53,7 +53,7 @@ resource "aws_ecs_task_definition" "prefect_agent_task_definition" {
   execution_role_arn = aws_iam_role.prefect_agent_execution_role.arn
   // Task role allows tasks and services to access other AWS resources
   // Use agent_task_role_arn if provided, otherwise populate with default
-  task_role_arn = coalesce(var.agent_task_role_arn, aws_iam_role.prefect_agent_task_role[0].arn)
+  task_role_arn = var.agent_task_role_arn == null ? aws_iam_role.prefect_agent_task_role[0].arn : var.agent_task_role_arn
 }
 
 resource "aws_ecs_service" "prefect_agent_service" {

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/ecs.tf
@@ -52,7 +52,8 @@ resource "aws_ecs_task_definition" "prefect_agent_task_definition" {
   // Execution role allows ECS to create tasks and services
   execution_role_arn = aws_iam_role.prefect_agent_execution_role.arn
   // Task role allows tasks and services to access other AWS resources
-  task_role_arn = aws_iam_role.prefect_agent_task_role.arn
+  // Use agent_task_role_arn if provided, otherwise populate with default
+  task_role_arn = coalesce(var.agent_task_role_arn, aws_iam_role.prefect_agent_task_role[0].arn)
 }
 
 resource "aws_ecs_service" "prefect_agent_service" {

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -58,6 +58,52 @@ resource "aws_iam_role" "prefect_agent_execution_role" {
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
+resource "aws_iam_role" "prefect_agent_task_role" {
+  name = "prefect-agent-task-role-${var.name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "prefect-agent-allow-ecs-task-${var.name}"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:GetLogEvents",
+            "logs:PutLogEvents",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:BatchGetImage",
+            "ecr:GetAuthorizationToken",
+            "ecr:GetDownloadUrlForLayer",
+            "ecs:DeregisterTaskDefinition",
+            "ecs:DescribeTasks",
+            "ecs:RegisterTaskDefinition",
+            "ecs:RunTask"
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}
+
 resource "aws_cloudwatch_log_group" "prefect_agent_log_group" {
   name              = "prefect-agent-log-group-${var.name}"
   retention_in_days = var.agent_log_retention_in_days

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -60,7 +60,7 @@ resource "aws_iam_role" "prefect_agent_execution_role" {
 
 resource "aws_iam_role" "prefect_agent_task_role" {
   name  = "prefect-agent-task-role-${var.name}"
-  count = var.agent_task_role_arn ? 1 : 0
+  count = var.agent_task_role_arn == null ? 1 : 0
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -59,7 +59,8 @@ resource "aws_iam_role" "prefect_agent_execution_role" {
 }
 
 resource "aws_iam_role" "prefect_agent_task_role" {
-  name = "prefect-agent-task-role-${var.name}"
+  name  = "prefect-agent-task-role-${var.name}"
+  count = var.agent_task_role_arn ? 1 : 0
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -81,10 +81,6 @@ resource "aws_iam_role" "prefect_agent_task_role" {
       Statement = [
         {
           Action = [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:GetLogEvents",
-            "logs:PutLogEvents",
             "ec2:DescribeSubnets",
             "ec2:DescribeVpcs",
             "ecr:BatchCheckLayerAvailability",
@@ -94,7 +90,12 @@ resource "aws_iam_role" "prefect_agent_task_role" {
             "ecs:DeregisterTaskDefinition",
             "ecs:DescribeTasks",
             "ecs:RegisterTaskDefinition",
-            "ecs:RunTask"
+            "ecs:RunTask",
+            "iam:PassRole",
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:GetLogEvents",
+            "logs:PutLogEvents"
           ]
           Effect   = "Allow"
           Resource = "*"

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
@@ -7,7 +7,7 @@ output "prefect_agent_execution_role_arn" {
 }
 
 output "prefect_agent_task_role_arn" {
-  value = coalesce(var.agent_task_role_arn, aws_iam_role.prefect_agent_task_role[0].arn)
+  value = var.agent_task_role_arn == null ? aws_iam_role.prefect_agent_task_role[0].arn : var.agent_task_role_arn
 }
 
 output "prefect_agent_security_group" {

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
@@ -7,13 +7,13 @@ output "prefect_agent_execution_role_arn" {
 }
 
 output "prefect_agent_task_role_arn" {
-  value = aws_iam_role.prefect_agent_task_role.arn
+  value = coalesce(var.agent_task_role_arn, aws_iam_role.prefect_agent_task_role[0].arn)
 }
 
 output "prefect_agent_security_group" {
   value = aws_security_group.prefect_agent.id
 }
 
-output "prefect_agent_cluster" {
+output "prefect_agent_cluster_name" {
   value = aws_ecs_cluster.prefect_agent_cluster.name
 }

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/outputs.tf
@@ -1,3 +1,19 @@
 output "prefect_agent_service_id" {
   value = aws_ecs_service.prefect_agent_service.id
 }
+
+output "prefect_agent_execution_role_arn" {
+  value = aws_iam_role.prefect_agent_execution_role.arn
+}
+
+output "prefect_agent_task_role_arn" {
+  value = aws_iam_role.prefect_agent_task_role.arn
+}
+
+output "prefect_agent_security_group" {
+  value = aws_security_group.prefect_agent.id
+}
+
+output "prefect_agent_cluster" {
+  value = aws_ecs_cluster.prefect_agent_cluster.name
+}

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
@@ -45,12 +45,6 @@ variable "agent_subnets" {
   type        = list(string)
 }
 
-variable "agent_task_role_arn" {
-  description = "Optional task role ARN to pass to the agent"
-  default     = ""
-  type        = string
-}
-
 variable "name" {
   description = "Unique name for this agent deployment"
   type        = string
@@ -71,7 +65,6 @@ variable "prefect_api_key" {
   type        = string
   sensitive   = true
 }
-
 
 variable "vpc_id" {
   description = "VPC ID in which to create all resources"

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
@@ -45,6 +45,12 @@ variable "agent_subnets" {
   type        = list(string)
 }
 
+variable "agent_task_role_arn" {
+  description = "Optional task role ARN to pass to the agent"
+  default     = null
+  type        = string
+}
+
 variable "name" {
   description = "Unique name for this agent deployment"
   type        = string

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
@@ -46,7 +46,7 @@ variable "agent_subnets" {
 }
 
 variable "agent_task_role_arn" {
-  description = "Optional task role ARN to pass to the agent"
+  description = "Optional task role ARN to pass to the agent. If not defined, a task role will be created"
   default     = null
   type        = string
 }


### PR DESCRIPTION
## Description

This PR changes the default behavior of the `agent_task_role_arn` variable. If the variable is set, everything behaves as before, in that the provided role is set as the Prefect agent service's task role. However, if the variable is not set, then we will now create a default task role that includes all permissions necessary for the agent to be able to use the ECSTask infrastructure type. Specifically,

```
ec2:DescribeSubnets
ec2:DescribeVpcs
ecr:BatchCheckLayerAvailability
ecr:BatchGetImage
ecr:GetAuthorizationToken
ecr:GetDownloadUrlForLayer
ecs:DeregisterTaskDefinition
ecs:DescribeTasks
ecs:RegisterTaskDefinition
ecs:RunTask
iam:PassRole
logs:CreateLogGroup
logs:CreateLogStream
logs:GetLogEvents
logs:PutLogEvents
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## New Recipe Checklist
<!-- If adding a new recipe, please ensure this list is completed. -->
- [x] My PR is in the format of `Add <project-name> recipe`
- [x] My recipe is reproducible and explains everything needed to run successfully. If my code has external dependencies, I make mention of them.
- [x] My code is easily understandable and/or well-commented.
- [x] If my recipe requires a new category (e.g. creating a monitoring/ folder in devops/), I have encapsulated my project within its own subfolder so that others can add their own recipes as well.
- [x] If my recipe uses Prefect < 2.0, my code is within the prefect-v1-legacy/ folder.