### PR TITLE
Update PR reminder Action

### DIFF
--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo Sending reminder to requested reviewers.
-      - uses: davideviolante/pr-reviews-reminder-action@v1.5.1
+      - uses: davideviolante/pr-reviews-reminder-action@v2.5.0
         env:
             GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
PR reminder GitHub Action needs to updated with latest version.

Error: https://github.com/PrefectHQ/prefect-recipes/actions/runs/3856635687

More info:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/