### PR TITLE
Chore: Bump versions, add dependabot.yml, black on changed files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/workflows/codeql.yml
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,10 +11,16 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3.3.0
 
+      - name: Get list of changed Python files
+        id: changed-files
+        run: |
+          echo ::set-output name=files::$(git diff --name-only HEAD $(git merge-base HEAD main) | grep ".py$")
+
       - name: black
         uses: rickstaa/action-black@v1
+        if: steps.changed-files.outputs.files != ''
         with:
-          black_args: ". --check --diff"
+          args: --check --diff --target=$(echo ${{ steps.changed-files.outputs.files }} | tr '\n' ' ')
           fail_on_error: true
 
       - name: setup python environment

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,17 +14,18 @@ jobs:
       - name: Get list of changed Python files
         id: changed-files
         run: |
-          echo ::set-output name=files::$(git diff --name-only HEAD $(git merge-base HEAD main) | grep ".py$")
+          echo ::set-output name=files::$(git diff --name-only HEAD origin/${{ github.base_ref }} | grep ".py$")
+          echo "Changed Python files: ${{ steps.changed-files.outputs.files }}"
 
       - name: black
-        uses: rickstaa/action-black@v1
+        uses: rickstaa/action-black@v2
         if: steps.changed-files.outputs.files != ''
         with:
           args: --check --diff --target=$(echo ${{ steps.changed-files.outputs.files }} | tr '\n' ' ')
           fail_on_error: true
 
       - name: setup python environment
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: "3.8"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,7 +18,7 @@ jobs:
           echo "Changed Python files: ${{ steps.changed-files.outputs.files }}"
 
       - name: black
-        uses: rickstaa/action-black@v2
+        uses: rickstaa/action-black@v1.3.0
         if: steps.changed-files.outputs.files != ''
         with:
           args: --check --diff --target=$(echo ${{ steps.changed-files.outputs.files }} | tr '\n' ' ')

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
 
       - name: black
         uses: rickstaa/action-black@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.3.0
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Get list of changed Python files
         id: changed-files

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Get list of changed Python files
         id: changed-files
         run: |
-          echo ::set-output name=files::$(git diff --name-only HEAD origin/${{ github.base_ref }} | grep ".py$")
+          echo ::set-output name=files::$(git diff --name-only HEAD origin/${{ github.head_ref }} | grep ".py$")
           echo "Changed Python files: ${{ steps.changed-files.outputs.files }}"
 
       - name: black

--- a/.github/workflows/terraform-action.yml
+++ b/.github/workflows/terraform-action.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
       
       - name: terraform format
         run: terraform fmt -recursive -check

--- a/.github/workflows/terraform-action.yml
+++ b/.github/workflows/terraform-action.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup terraform
         uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
We're unable to merge any PRs until they can pass the Python checks, which I believe is currently failing on black due to files which are already in main. So, a quick solution is to run the black check on changed files only.