### PR TITLE
add secrets manager recovery variable

### DIFF
--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -12,6 +12,7 @@ data "aws_region" "current" {}
 
 resource "aws_secretsmanager_secret" "prefect_api_key" {
   name = "prefect-api-key-${var.name}"
+  recovery_window_in_days = var.secrets_manager_recovery_in_days
 }
 
 resource "aws_secretsmanager_secret_version" "prefect_api_key_version" {

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/variables.tf
@@ -76,3 +76,9 @@ variable "vpc_id" {
   description = "VPC ID in which to create all resources"
   type        = string
 }
+
+variable "secrets_manager_recovery_in_days" {
+  type        = number
+  default     = 30
+  description = "Deletion delay for AWS Secrets Manager upon resource destruction"
+}


### PR DESCRIPTION
## Description

The default behavior of the `recovery_window_in_days` argument in the `aws_secretsmanager_secret` resource has been modified by this PR. When the variable is defined, it determines the amount of time that AWS Secrets Manager must wait before deleting the secret. However, if the variable is undefined, the default waiting period will now be applied.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## New Recipe Checklist
<!-- If adding a new recipe, please ensure this list is completed. -->
- [x] My PR is in the format of `Add <project-name> recipe`
- [x] My recipe is reproducible and explains everything needed to run successfully. If my code has external dependencies, I make mention of them.
- [x] My code is easily understandable and/or well-commented.
- [x] If my recipe requires a new category (e.g. creating a monitoring/ folder in devops/), I have encapsulated my project within its own subfolder so that others can add their own recipes as well.
- [x] If my recipe uses Prefect < 2.0, my code is within the prefect-v1-legacy/ folder.