### PR TITLE
Add declarative-graph-orchestrator recipe

### DIFF
--- a/flows-advanced/declarative-graph-orchestrator/README.md
+++ b/flows-advanced/declarative-graph-orchestrator/README.md
@@ -1,0 +1,19 @@
+### Declarative Graph Orchestrator
+This recipe demonstrates a way to have many disjoint deployments executed in a graph by using tags to build the graph.  
+The main entry point `run_orchestrator_flow()` takes an argument, `filter_tags`, for passing in a filter condition for
+fetching the set of related deployments.  For example, suppose you have many deployments for training many different models,
+but some models depend on other model deployment runs to have finished first.  First, you would tag all the related model
+training deployments with some tag, let's suppose `group:ml`.  Next, to specify dependencies, you would also
+tag deployments with `depends_on:<flow name>/<deployment name>` to specify a dependency.  Here's an example:
+
+<img width="923" alt="Screenshot 2023-04-13 at 9 32 48 AM" src="https://user-images.githubusercontent.com/4908576/231779337-768303e4-82f9-4c3f-bbef-7de6212dcc3f.png">
+
+When you run the orchestrator flow, you would do something like this:
+```python
+@flow(name="orchestration-test-flow")
+async def example_flow():
+    await run_orchestrator_flow(DeploymentFilterTags(all_=["group:ml"]))
+```
+
+And this is the result:
+<img width="1097" alt="Screenshot 2023-04-13 at 9 37 48 AM" src="https://user-images.githubusercontent.com/4908576/231779682-a64fc9eb-a202-4216-b0cd-acbb2ea44a1e.png">

--- a/flows-advanced/declarative-graph-orchestrator/README.md
+++ b/flows-advanced/declarative-graph-orchestrator/README.md
@@ -15,5 +15,7 @@ async def example_flow():
     await run_orchestrator_flow(DeploymentFilterTags(all_=["group:ml"]))
 ```
 
+Since the orchestrator flow creates flow runs via deployments, you'll also need to start an agent to consume them: `prefect agent start -q default`
+
 And this is the result:
 <img width="1097" alt="Screenshot 2023-04-13 at 9 37 48 AM" src="https://user-images.githubusercontent.com/4908576/231779682-a64fc9eb-a202-4216-b0cd-acbb2ea44a1e.png">

--- a/flows-advanced/declarative-graph-orchestrator/deploy.py
+++ b/flows-advanced/declarative-graph-orchestrator/deploy.py
@@ -1,0 +1,58 @@
+from prefect import flow, get_run_logger
+from prefect.deployments import Deployment
+
+
+@flow(name="run")
+async def dbt_flow():
+    get_run_logger().info("Running DBT job...")
+
+
+@flow(name="train")
+async def model1_flow():
+    get_run_logger().info("Running Model 1 training job...")
+
+
+@flow(name="train")
+async def model2_flow():
+    get_run_logger().info("Running Model 2 training job...")
+
+
+@flow(name="train")
+async def model3_flow():
+    get_run_logger().info("Running Model 3 training job...")
+
+
+dbt_1 = Deployment.build_from_flow(
+    name="dbt",
+    flow=dbt_flow,
+    tags=[]
+).apply()
+
+model_1 = Deployment.build_from_flow(
+    name="model-1",
+    flow=model1_flow,
+    tags=[
+        "group:ml",
+        "depends_on:run/dbt"
+    ]
+).apply()
+
+model_2 = Deployment.build_from_flow(
+    name="model-2",
+    flow=model2_flow,
+    tags=[
+        "group:ml",
+        "depends_on:run/dbt"
+    ]
+).apply()
+
+
+model_3 = Deployment.build_from_flow(
+    name="model-3",
+    flow=model3_flow,
+    tags=[
+        "group:ml",
+        "depends_on:train/model-1",
+        "depends_on:train/model-2",
+    ]
+).apply()

--- a/flows-advanced/declarative-graph-orchestrator/deploy.py
+++ b/flows-advanced/declarative-graph-orchestrator/deploy.py
@@ -7,17 +7,17 @@ async def dbt_flow():
     get_run_logger().info("Running DBT job...")
 
 
-@flow(name="train")
+@flow(name="train model 1")
 async def model1_flow():
     get_run_logger().info("Running Model 1 training job...")
 
 
-@flow(name="train")
+@flow(name="train model 2")
 async def model2_flow():
     get_run_logger().info("Running Model 2 training job...")
 
 
-@flow(name="train")
+@flow(name="train model 3")
 async def model3_flow():
     get_run_logger().info("Running Model 3 training job...")
 

--- a/flows-advanced/declarative-graph-orchestrator/orchestration.py
+++ b/flows-advanced/declarative-graph-orchestrator/orchestration.py
@@ -1,0 +1,92 @@
+import asyncio
+from typing import Dict, List
+
+import networkx as nx
+from prefect import get_client, task, flow
+from prefect.deployments import run_deployment
+from prefect.logging import get_run_logger
+from prefect.server.schemas.filters import DeploymentFilterTags, DeploymentFilter
+
+
+async def _get_deployments_with_dependencies(filter_tags: DeploymentFilterTags) -> Dict[str, List[str]]:
+    """
+    Get deployments that match the filter and build a dictionary of {deployment -> list of upstream deployments}
+    """
+    result = dict()
+
+    async with get_client() as client:
+        deployments = await client.read_deployments(
+            deployment_filter=DeploymentFilter(
+                tags=filter_tags
+            )
+        )
+
+        for deployment in deployments:
+            dependencies = []
+            for tag in deployment.tags:
+                if not tag.startswith("depends_on:"):
+                    continue
+
+                parts = tag.split(":", 2)
+                dependencies.append(parts[1])
+
+            deployment_flow = await client.read_flow(deployment.flow_id)
+            result[f"{deployment_flow.name}/{deployment.name}"] = dependencies
+
+    return result
+
+
+async def _construct_nx_graph(deployments: Dict[str, List[str]]) -> nx.DiGraph:
+    """
+    Constructs a DAG from our dictionary of {deployment -> list of upstream deployments}
+    """
+    nodes = []
+    edges = []
+
+    for node, upstreams in deployments.items():
+        nodes.append(node)
+        for upstream in upstreams:
+            edge = (upstream, node)
+            edges.append(edge)
+
+    graph = nx.DiGraph()
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
+    return graph
+
+
+async def run_orchestrator_flow(filter_tags: DeploymentFilterTags) -> None:
+    """
+    Runs an orchestrator flow by constructing a graph of deployments to execute, where :filter_tags specifies which
+    deployments to build the graph from, and using the 'depends_on' tag to specify dependencies between deployments.
+    Deployment flows are then executed in topological order, based on these dependencies.
+    """
+    deployments = await _get_deployments_with_dependencies(filter_tags)
+
+    if len(deployments) == 0:
+        get_run_logger().warning("No deployments found for given filter")
+        return
+
+    graph = await _construct_nx_graph(deployments)
+    futures = dict()
+
+    for deployment_name in nx.topological_sort(graph):
+        upstream_deployment_names = list(graph.predecessors(deployment_name))
+        upstream_deployment_futures = [futures[t] for t in upstream_deployment_names]
+        get_run_logger().info(f"Submitting task {deployment_name}")
+
+        @task(name=deployment_name)
+        async def worker_task(name: str):
+            get_run_logger().info(f"Running deployment {name}")
+            await run_deployment(name)
+
+        futures[deployment_name] = await worker_task.submit(
+            name=deployment_name,
+            wait_for=upstream_deployment_futures,
+        )
+
+@flow(name="orchestration-test-flow")
+async def example_flow():
+    await run_orchestrator_flow(DeploymentFilterTags(all_=["group:ml"]))
+
+asyncio.run(example_flow())

--- a/flows-advanced/declarative-graph-orchestrator/orchestration.py
+++ b/flows-advanced/declarative-graph-orchestrator/orchestration.py
@@ -89,4 +89,5 @@ async def run_orchestrator_flow(filter_tags: DeploymentFilterTags) -> None:
 async def example_flow():
     await run_orchestrator_flow(DeploymentFilterTags(all_=["group:ml"]))
 
-asyncio.run(example_flow())
+if __name__ == "__main__":
+    asyncio.run(example_flow())

--- a/flows-advanced/declarative-graph-orchestrator/requirements.txt
+++ b/flows-advanced/declarative-graph-orchestrator/requirements.txt
@@ -1,0 +1,2 @@
+networkx==3.1
+prefect==2.9.0


### PR DESCRIPTION
## Description
A recipe for how to orchestrate running a graph of deployments by defining the graph declaratively via tags.

## New Recipe Checklist
<!-- If adding a new recipe, please ensure this list is completed. -->
- [x] My PR is in the format of `Add <project-name> recipe`
- [x] My recipe is reproducible and explains everything needed to run successfully. If my code has external dependencies, I make mention of them.
- [x] My code is easily understandable and/or well-commented.
- [x] If my recipe requires a new category (e.g. creating a monitoring/ folder in devops/), I have encapsulated my project within its own subfolder so that others can add their own recipes as well.
- [x] If my recipe uses Prefect < 2.0, my code is within the prefect-v1-legacy/ folder.