### PR TITLE
Add info on agents/work queues, rename some Prefect 1 legacy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,17 +214,20 @@ What are you interested in seeing examples of? [Jot down your big idea here.](ht
 #### Miscellaneous
 - [Merge Dependabot Pull Requests with Prefect 2 & a GitHubCredentials block](./flows-advanced/merge_dependabot_pull_requests.py)
 
+#### Discourse
+[Prefect Agents and Work-Queues FAQ](https://discourse.prefect.io/t/agents-and-work-queues-faq/1468)
+
 #### Prefect 1.0 Legacy
-- [Register a Prefect Flow](./prefect-v1-legacy/devops/github-actions/)
+- [Register a Prefect 1 Flow](./prefect-v1-legacy/devops/github-actions/)
 - [Run GraphQL Queries](./prefect-v1-legacy/graphql-queries/)
 - [Airbyte Orchestration](./prefect-v1-legacy/use-cases/airbyte-orchestration/)
 - [ETL with AWS S3 and Snowflake](./prefect-v1-legacy/use-cases/etl-s3-to-snowflake/)
 - [Use AWS Lambda for Event-Driven Flows](./prefect-v1-legacy/use-cases/event-driven-triggers/)
-- [Read Secrets into Prefect Cloud tenant](./prefect-v1-legacy/use-cases/import-secrets-to-cloud/)
+- [Read Secrets into Prefect 1 Cloud tenant](./prefect-v1-legacy/use-cases/import-secrets-to-cloud/)
 - [Handle DBT Model Failures](./prefect-v1-legacy/use-cases/rerun_dbt_models_from_failure/)
-- [S3 Flow Storage on EKS](./prefect-v1-legacy/use-cases/s3-flow-storage-on-eks/)
+- [S3 Prefect 1 Flow Storage on EKS](./prefect-v1-legacy/use-cases/s3-flow-storage-on-eks/)
 - [Use LocalExecutor to run Dask computations on a Coiled cluster](https://docs.coiled.io/user_guide/examples/prefect.html#using-the-localexecutor)
-- [Use DaskExecutor to run Prefect tasks in parallel on a Coiled cluster](https://docs.coiled.io/user_guide/examples/prefect.html#using-the-daskexecutor)
+- [Use DaskExecutor to run Prefect 1 tasks in parallel on a Coiled cluster](https://docs.coiled.io/user_guide/examples/prefect.html#using-the-daskexecutor)
 
 ## Contributions
 We're always looking for new contributions! You can add your Prefect 2.0 recipe and earn some swag in a few simple steps:


### PR DESCRIPTION
## Description

Also add a discourse article on agents/work queues (this might be useful in case info about those do go away from the docs at some point).
Specify legacy Prefect links as Prefect 1 to lessen confusion.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] README change