### PR TITLE
Add GHA templates for deploying flows only when necessary...

### DIFF
--- a/devops/github-actions/prefect-deploy-only-when-files-change-including-docker-build.yaml
+++ b/devops/github-actions/prefect-deploy-only-when-files-change-including-docker-build.yaml
@@ -1,0 +1,71 @@
+---
+name: Build and publish Prefect Deployments & Docker images
+
+"on":
+  push:
+    branches:
+      - main
+
+# Do not grant jobs any permissions by default
+permissions: {}
+
+jobs:
+  deploy_flows:
+    name: Build Prefect deployment images
+    runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
+      # required to obtain Google Cloud service account credentials
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v2
+        id: prefect_filter
+        with:
+          filters: |
+            flow_1:
+              - deployments/flow-1/**
+            flow_2:
+              - deployments/flow-2/**
+
+      # The following two steps are specific to authentication against GCP - these are used to allow the workflow to push the 
+      # Docker images built to GCP. Plug in your own authentication method if not using GCP
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: GCP_WORKLOAD_IDENTITY
+          service_account: GCP_SERVICE_ACCOUNT
+      - name: Configure Google Cloud credential helper
+        run: gcloud auth configure-docker --quiet us-docker.pkg.dev
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Auth to Prefect Cloud
+        uses: PrefectHQ/actions-prefect-auth@v1
+        with:
+          prefect-api-key: ${{ secrets.PREFECT_API_KEY }}
+          prefect-workspace: PREFECT_ACCOUNT/PREFECT_WORKSPACE
+
+      - name: Deploy flow 1
+        if: steps.prefect_filter.outputs.flow_2 == 'true'
+        uses: PrefectHQ/actions-prefect-deploy@v3
+        with:
+          deployment-names: Flow 1
+          requirements-file-paths: deployments/flow-1/requirements.txt
+
+      - name: Deploy flow 2
+        if: steps.prefect_filter.outputs.flow_1 == 'true'
+        uses: PrefectHQ/actions-prefect-deploy@v3
+        with:
+          deployment-names: Flow 2
+          requirements-file-paths: deployments/flow-2/requirements.txt
+
+

--- a/devops/github-actions/prefect-deploy-only-when-files-change-no-docker-build.yaml
+++ b/devops/github-actions/prefect-deploy-only-when-files-change-no-docker-build.yaml
@@ -1,0 +1,59 @@
+---
+name: Build and publish Prefect Deployments
+
+"on":
+  push:
+    branches:
+      - main
+
+# Do not grant jobs any permissions by default
+permissions: {}
+
+jobs:
+  deploy_flows:
+    name: Build Prefect deployment images
+    runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
+      # required to obtain Google Cloud service account credentials
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v2
+        id: prefect_filter
+        with:
+          filters: |
+            flow_1:
+              - deployments/flow-1/**
+            flow_2:
+              - deployments/flow-2/**
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Auth to Prefect Cloud
+        uses: PrefectHQ/actions-prefect-auth@v1
+        with:
+          prefect-api-key: ${{ secrets.PREFECT_API_KEY }}
+          prefect-workspace: PREFECT_ACCOUNT/PREFECT_WORKSPACE
+
+      - name: Deploy flow 1
+        if: steps.prefect_filter.outputs.flow_2 == 'true'
+        uses: PrefectHQ/actions-prefect-deploy@v3
+        with:
+          deployment-names: Flow 1
+
+      - name: Deploy flow 2
+        if: steps.prefect_filter.outputs.flow_1 == 'true'
+        uses: PrefectHQ/actions-prefect-deploy@v3
+        with:
+          deployment-names: Flow 2
+
+


### PR DESCRIPTION
## Description
... as determined by code changes. Both recipes will evaluate (on merge to main) whether or not the defined Prefect deployments have experienced any changes, based on file path diffs. If they have, it will re-deploy the flow to Prefect Cloud.

The second of the two recipes (`-including-docker-build`) supports the ability to build & push a docker image associated with the Deployments.

What's cooking? 
If this PR references an issue, please attach to the existing issue.
Resolves https://github.com/PrefectHQ/platform/issues/4017

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## New Recipe Checklist
<!-- If adding a new recipe, please ensure this list is completed. -->
- [x] My PR is in the format of `Add <project-name> recipe`
- [x] My recipe is reproducible and explains everything needed to run successfully. If my code has external dependencies, I make mention of them.
- [x] My code is easily understandable and/or well-commented.
- [x] If my recipe requires a new category (e.g. creating a monitoring/ folder in devops/), I have encapsulated my project within its own subfolder so that others can add their own recipes as well.
- [x] If my recipe uses Prefect < 2.0, my code is within the prefect-v1-legacy/ folder.