### PR TITLE
Adds ecs:StopTask permission

### DIFF
--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-agent/main.tf
@@ -108,6 +108,7 @@ resource "aws_iam_role" "prefect_agent_task_role" {
             "ecs:DescribeTasks",
             "ecs:RegisterTaskDefinition",
             "ecs:RunTask",
+            "ecs:StopTask",
             "iam:PassRole",
             "logs:CreateLogGroup",
             "logs:CreateLogStream",

--- a/devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker/main.tf
+++ b/devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker/main.tf
@@ -109,6 +109,7 @@ resource "aws_iam_role" "prefect_worker_task_role" {
             "ecs:DescribeTasks",
             "ecs:RegisterTaskDefinition",
             "ecs:RunTask",
+            "ecs:StopTask",
             "iam:PassRole",
             "logs:CreateLogGroup",
             "logs:CreateLogStream",


### PR DESCRIPTION
Adds the `ecs:StopTask` permission to the ECS agent and worker recipes. This permission is necessary for cancellation to work. Without it, cancellation will result in a permissions error.